### PR TITLE
Fix README example and incorrectly named test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ pub enum Error {
 
 #[remain::sorted]
 #[derive(Debug)]
-pub enum Registers {
+pub struct Registers {
     ax: u16,
     cx: u16,
     di: u16,

--- a/tests/stable.rs
+++ b/tests/stable.rs
@@ -18,7 +18,7 @@ pub struct TestStruct {
 
 #[test]
 #[remain::check]
-fn test_match() {
+fn test_let() {
     let value = TestEnum::A;
 
     #[sorted]
@@ -32,7 +32,7 @@ fn test_match() {
 
 #[test]
 #[remain::check]
-fn test_let() {
+fn test_match() {
     let value = TestEnum::A;
 
     #[sorted]

--- a/tests/unstable.rs
+++ b/tests/unstable.rs
@@ -19,7 +19,7 @@ pub struct TestStruct {
 }
 
 #[test]
-fn test_match() {
+fn test_let() {
     let value = TestEnum::A;
 
     #[remain::sorted]
@@ -32,7 +32,7 @@ fn test_match() {
 }
 
 #[test]
-fn test_let() {
+fn test_match() {
     let value = TestEnum::A;
 
     #[remain::sorted]


### PR DESCRIPTION
Fixes the `Registers` example.

Fixes the `test_let` and `test_match` cases for stable and unstable being named the wrong way around.