### PR TITLE
Add an #[unsorted] attribute to allow certain cases to be ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ pub enum Error {
 
 #[remain::sorted]
 #[derive(Debug)]
-pub enum Registers {
+pub struct Registers {
     ax: u16,
     cx: u16,
     di: u16,

--- a/src/check.rs
+++ b/src/check.rs
@@ -7,20 +7,11 @@ use crate::compare::Path;
 use crate::format;
 use crate::parse::Input::{self, *};
 
-pub fn sorted(input: Input) -> Result<proc_macro2::TokenStream> {
-    let (output, paths) = match input {
-        Enum(mut item) => {
-            let paths = filter_unsorted_enum(&mut item)?;
-            (quote!(#item), paths)
-        }
-        Struct(mut item) => {
-            let paths = filter_unsorted_struct(&mut item)?;
-            (quote!(#item), paths)
-        }
-        Match(mut expr) | Let(mut expr) => {
-            let paths = filter_unsorted_match(&mut expr)?;
-            (quote!(#expr), paths)
-        }
+pub fn sorted(input: &mut Input) -> Result<()> {
+    let paths = match input {
+        Enum(item) => filter_unsorted_enum(item)?,
+        Struct(item) => filter_unsorted_struct(item)?,
+        Match(expr) | Let(expr) => filter_unsorted_match(expr)?,
     };
 
     for i in 1..paths.len() {
@@ -33,7 +24,7 @@ pub fn sorted(input: Input) -> Result<proc_macro2::TokenStream> {
         }
     }
 
-    Ok(output)
+    Ok(())
 }
 
 fn take_unsorted_attr(attrs: &mut Vec<Attribute>) -> bool {

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -11,7 +11,7 @@ pub enum Kind {
     Let,
 }
 
-pub fn emit(err: Error, kind: Kind, original: TokenStream) -> TokenStream {
+pub fn emit(err: Error, kind: Kind, output: TokenStream) -> TokenStream {
     let mut err = err;
     if !probably_has_spans(kind) {
         // Otherwise the error is printed without any line number.
@@ -19,11 +19,11 @@ pub fn emit(err: Error, kind: Kind, original: TokenStream) -> TokenStream {
     }
 
     let err = err.to_compile_error();
-    let original = proc_macro2::TokenStream::from(original);
+    let output = proc_macro2::TokenStream::from(output);
 
     let expanded = match kind {
-        Kind::Enum | Kind::Let | Kind::Struct => quote!(#err #original),
-        Kind::Match => quote!({ #err #original }),
+        Kind::Enum | Kind::Let | Kind::Struct => quote!(#err #output),
+        Kind::Match => quote!({ #err #output }),
     };
 
     TokenStream::from(expanded)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,7 @@ pub fn unsorted(args: TokenStream, input: TokenStream) -> TokenStream {
     // This attribute will always give a compile error, since it should only be used inside of a
     // #[remain::sorted] check, where it will be removed.
 
-    let msg = "#[remain::unsorted] is only supported inside of a #[remain::sorted]";
+    let msg = "#[remain::unsorted] is unsupported outside of #[remain::sorted]";
     let err = Error::new_spanned(args, msg).to_compile_error();
     TokenStream::from(quote! {
         #err

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -15,7 +15,7 @@ impl Parse for Nothing {
 pub enum Input {
     Enum(syn::ItemEnum),
     Match(syn::ExprMatch),
-    Struct(syn::FieldsNamed),
+    Struct(syn::ItemStruct),
     Let(syn::ExprMatch),
 }
 
@@ -64,8 +64,8 @@ impl Parse for Input {
             return input.parse().map(Input::Enum);
         } else if ahead.peek(Token![struct]) {
             let input: syn::ItemStruct = input.parse()?;
-            if let Fields::Named(fields) = input.fields {
-                return Ok(Input::Struct(fields));
+            if let Fields::Named(_) = &input.fields {
+                return Ok(Input::Struct(input));
             }
         }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,4 +1,5 @@
-use proc_macro2::Span;
+use proc_macro2::{Span, TokenStream};
+use syn::export::ToTokens;
 use syn::parse::{Parse, ParseStream};
 use syn::{Attribute, Error, Expr, Fields, Result, Stmt, Token, Visibility};
 
@@ -70,6 +71,16 @@ impl Parse for Input {
         }
 
         Err(unexpected())
+    }
+}
+
+impl ToTokens for Input {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self {
+            Input::Enum(item) => item.to_tokens(tokens),
+            Input::Struct(item) => item.to_tokens(tokens),
+            Input::Match(expr) | Input::Let(expr) => expr.to_tokens(tokens),
+        }
     }
 }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -33,9 +33,10 @@ impl Input {
 
 impl Parse for Input {
     fn parse(input: ParseStream) -> Result<Self> {
-        let _ = input.call(Attribute::parse_outer)?;
+        let ahead = input.fork();
+        let _ = ahead.call(Attribute::parse_outer)?;
 
-        if input.peek(Token![match]) {
+        if ahead.peek(Token![match]) {
             let expr = match input.parse()? {
                 Expr::Match(expr) => expr,
                 _ => unreachable!("expected match"),
@@ -43,7 +44,7 @@ impl Parse for Input {
             return Ok(Input::Match(expr));
         }
 
-        if input.peek(Token![let]) {
+        if ahead.peek(Token![let]) {
             let stmt = match input.parse()? {
                 Stmt::Local(stmt) => stmt,
                 _ => unreachable!("expected let"),
@@ -59,7 +60,6 @@ impl Parse for Input {
             return Ok(Input::Let(expr));
         }
 
-        let ahead = input.fork();
         let _: Visibility = ahead.parse()?;
         if ahead.peek(Token![enum]) {
             return input.parse().map(Input::Enum);

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -64,16 +64,15 @@ fn take_sorted_attr(attrs: &mut Vec<Attribute>) -> bool {
 }
 
 fn check_and_insert_error(input: ExprMatch, out: &mut Expr) {
-    let original = quote!(#input);
-    let input = Input::Match(input);
+    let mut input = Input::Match(input);
 
-    *out = match crate::check::sorted(input) {
-        Ok(output) => parse_quote!(#output),
+    *out = match crate::check::sorted(&mut input) {
+        Ok(_) => parse_quote!(#input),
         Err(err) => {
             let err = err.to_compile_error();
             parse_quote!({
                 #err
-                #original
+                #input
             })
         }
     };

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -67,11 +67,14 @@ fn check_and_insert_error(input: ExprMatch, out: &mut Expr) {
     let original = quote!(#input);
     let input = Input::Match(input);
 
-    if let Err(err) = crate::check::sorted(input) {
-        let err = err.to_compile_error();
-        *out = parse_quote!({
-            #err
-            #original
-        });
-    }
+    *out = match crate::check::sorted(input) {
+        Ok(output) => parse_quote!(#output),
+        Err(err) => {
+            let err = err.to_compile_error();
+            parse_quote!({
+                #err
+                #original
+            })
+        }
+    };
 }

--- a/tests/stable.rs
+++ b/tests/stable.rs
@@ -4,7 +4,11 @@
 pub enum TestEnum {
     A,
     B,
+    #[remain::unsorted]
+    Ignored,
     C,
+    #[unsorted]
+    AlsoIgnored,
     D,
 }
 
@@ -12,7 +16,11 @@ pub enum TestEnum {
 pub struct TestStruct {
     a: usize,
     b: usize,
+    #[unsorted]
+    ignored: usize,
     c: usize,
+    #[remain::unsorted]
+    also_ignored: usize,
     d: usize,
 }
 
@@ -24,7 +32,11 @@ fn test_let() {
     #[sorted]
     let _ = match value {
         TestEnum::A => {}
+        #[remain::unsorted]
+        TestEnum::Ignored => {}
         TestEnum::B => {}
+        #[unsorted]
+        TestEnum::AlsoIgnored => {}
         TestEnum::C => {}
         _ => {}
     };
@@ -39,7 +51,11 @@ fn test_match() {
     match value {
         TestEnum::A => {}
         TestEnum::B => {}
+        #[unsorted]
+        TestEnum::Ignored => {}
         TestEnum::C => {}
+        #[remain::unsorted]
+        TestEnum::AlsoIgnored => {}
         _ => {}
     }
 }

--- a/tests/stable.rs
+++ b/tests/stable.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 #[remain::sorted]
+#[derive(PartialEq)]
 pub enum TestEnum {
     A,
     B,
@@ -13,6 +14,7 @@ pub enum TestEnum {
 }
 
 #[remain::sorted]
+#[derive(PartialEq)]
 pub struct TestStruct {
     a: usize,
     b: usize,
@@ -22,6 +24,16 @@ pub struct TestStruct {
     #[remain::unsorted]
     also_ignored: usize,
     d: usize,
+}
+
+#[test]
+fn test_attrs() {
+    fn is_partial_eq<T: PartialEq>() -> bool {
+        true
+    }
+
+    assert!(is_partial_eq::<TestEnum>());
+    assert!(is_partial_eq::<TestStruct>());
 }
 
 #[test]

--- a/tests/stable.rs
+++ b/tests/stable.rs
@@ -18,7 +18,7 @@ pub struct TestStruct {
 
 #[test]
 #[remain::check]
-fn test_match() {
+fn test_let() {
     let value = TestEnum::A;
 
     #[sorted]
@@ -32,7 +32,7 @@ fn test_match() {
 
 #[test]
 #[remain::check]
-fn test_let() {
+fn test_match() {
     let value = TestEnum::A;
 
     #[sorted]

--- a/tests/ui/unsorted-enum.rs
+++ b/tests/ui/unsorted-enum.rs
@@ -1,0 +1,12 @@
+use remain::sorted;
+
+#[sorted]
+enum E {
+    Aaa,
+    Ccc(u8),
+    #[unsorted]
+    Ddd { u: u8 },
+    Bbb(u8, u8),
+}
+
+fn main() {}

--- a/tests/ui/unsorted-enum.stderr
+++ b/tests/ui/unsorted-enum.stderr
@@ -1,0 +1,5 @@
+error: Bbb should sort before Ccc
+ --> $DIR/unsorted-enum.rs:9:5
+  |
+9 |     Bbb(u8, u8),
+  |     ^^^

--- a/tests/ui/unsorted-match-stable.rs
+++ b/tests/ui/unsorted-match-stable.rs
@@ -1,0 +1,20 @@
+enum E {
+    Aaa,
+    Bbb(u8, u8),
+    Ccc(u8),
+    Ddd { u: u8 },
+}
+
+#[remain::check]
+fn main() {
+    let value = E::Aaa;
+
+    #[sorted]
+    match value {
+        E::Aaa => {}
+        E::Ccc(_) => {}
+        #[unsorted]
+        E::Ddd { u: _ } => {}
+        E::Bbb(_, _) => {}
+    }
+}

--- a/tests/ui/unsorted-match-stable.stderr
+++ b/tests/ui/unsorted-match-stable.stderr
@@ -1,0 +1,5 @@
+error: E::Bbb should sort before E::Ccc
+  --> $DIR/unsorted-match-stable.rs:18:9
+   |
+18 |         E::Bbb(_, _) => {}
+   |         ^^^^^^

--- a/tests/ui/unsorted-match-unstable.rs
+++ b/tests/ui/unsorted-match-unstable.rs
@@ -1,0 +1,23 @@
+#![feature(proc_macro_hygiene, stmt_expr_attributes)]
+
+use remain::sorted;
+
+enum E {
+    Aaa,
+    Bbb(u8, u8),
+    Ccc(u8),
+    Ddd { u: u8 },
+}
+
+fn main() {
+    let value = E::Aaa;
+
+    #[sorted]
+    match value {
+        E::Aaa => {}
+        #[unsorted]
+        E::Ccc(_) => {}
+        E::Ddd { u: _ } => {}
+        E::Bbb(_, _) => {}
+    }
+}

--- a/tests/ui/unsorted-match-unstable.stderr
+++ b/tests/ui/unsorted-match-unstable.stderr
@@ -1,0 +1,5 @@
+error: E::Bbb should sort before E::Ddd
+  --> $DIR/unsorted-match-unstable.rs:15:5
+   |
+15 |     #[sorted]
+   |     ^^^^^^^^^

--- a/tests/ui/unsorted-struct.rs
+++ b/tests/ui/unsorted-struct.rs
@@ -1,0 +1,12 @@
+use remain::sorted;
+
+#[sorted]
+struct TestStruct {
+    d: usize,
+    #[unsorted]
+    c: usize,
+    a: usize,
+    b: usize,
+}
+
+fn main() {}

--- a/tests/ui/unsorted-struct.stderr
+++ b/tests/ui/unsorted-struct.stderr
@@ -1,0 +1,5 @@
+error: a should sort before d
+ --> $DIR/unsorted-struct.rs:8:5
+  |
+8 |     a: usize,
+  |     ^

--- a/tests/unstable.rs
+++ b/tests/unstable.rs
@@ -5,6 +5,8 @@
 #[remain::sorted]
 pub enum TestEnum {
     A,
+    #[remain::unsorted]
+    Ignored,
     B,
     C,
     D,
@@ -15,6 +17,8 @@ pub struct TestStruct {
     a: usize,
     b: usize,
     c: usize,
+    #[unsorted]
+    ignored: usize,
     d: usize,
 }
 
@@ -25,6 +29,8 @@ fn test_let() {
     #[remain::sorted]
     let _ = match value {
         TestEnum::A => {}
+        #[remain::unsorted]
+        TestEnum::Ignored => {}
         TestEnum::B => {}
         TestEnum::C => {}
         _ => {}
@@ -39,6 +45,8 @@ fn test_match() {
     match value {
         TestEnum::A => {}
         TestEnum::B => {}
+        #[unsorted]
+        TestEnum::Ignored => {}
         TestEnum::C => {}
         _ => {}
     }

--- a/tests/unstable.rs
+++ b/tests/unstable.rs
@@ -19,7 +19,7 @@ pub struct TestStruct {
 }
 
 #[test]
-fn test_match() {
+fn test_let() {
     let value = TestEnum::A;
 
     #[remain::sorted]
@@ -32,7 +32,7 @@ fn test_match() {
 }
 
 #[test]
-fn test_let() {
+fn test_match() {
     let value = TestEnum::A;
 
     #[remain::sorted]

--- a/tests/unstable.rs
+++ b/tests/unstable.rs
@@ -3,6 +3,7 @@
 #![feature(proc_macro_hygiene, stmt_expr_attributes)]
 
 #[remain::sorted]
+#[derive(PartialEq)]
 pub enum TestEnum {
     A,
     #[remain::unsorted]
@@ -13,6 +14,7 @@ pub enum TestEnum {
 }
 
 #[remain::sorted]
+#[derive(PartialEq)]
 pub struct TestStruct {
     a: usize,
     b: usize,
@@ -20,6 +22,16 @@ pub struct TestStruct {
     #[unsorted]
     ignored: usize,
     d: usize,
+}
+
+#[test]
+fn test_attrs() {
+    fn is_partial_eq<T: PartialEq>() -> bool {
+        true
+    }
+
+    assert!(is_partial_eq::<TestEnum>());
+    assert!(is_partial_eq::<TestStruct>());
 }
 
 #[test]


### PR DESCRIPTION
Add `#[unsorted]` attribute to be used inside of blocks marked with `#[sorted]`. The attribute allows for cases marked with it to be ignored by the checks.

The attribute can be used as `#[remain::unsorted]` or `#[unsorted]`.

The attribute is not a real attribute macro and is stripped when the checks for `#[sorted]` are done, but is labelled as such due to the usage of it.

<details>
<summary>Example 1</summary>

```rust
#[remain::sorted]
pub enum TestEnum {
    Aaa,
    Bbb,
    #[remain::unsorted]
    ThisIsIgnored,
    Ccc,
    Ddd,
}
```
</details>

<details>
<summary>Example 2</summary>

```rust
#[remain::sorted]
pub enum TestEnum {
    Aaa,
    Bbb,
    Ccc,
	#[unsorted]
	#[doc(hidden)
    __Nonexhaustive,
}
```
</details>