### PR TITLE
Add support for sorting impl Item

### DIFF
--- a/src/compare.rs
+++ b/src/compare.rs
@@ -1,7 +1,7 @@
 use proc_macro2::Ident;
 use std::cmp::Ordering;
 
-use crate::atom::iter_atoms;
+use crate::{atom::iter_atoms, check::Category};
 
 #[derive(Copy, Clone, PartialEq)]
 pub enum UnderscoreOrder {
@@ -13,16 +13,21 @@ pub struct Path {
     pub segments: Vec<Ident>,
 }
 
-pub fn cmp(lhs: &Path, rhs: &Path, mode: UnderscoreOrder) -> Ordering {
+pub fn cmp(lhs: &(Category, Path), rhs: &(Category, Path), mode: UnderscoreOrder) -> Ordering {
+    match lhs.0.cmp(&rhs.0) {
+        Ordering::Equal => {}
+        non_eq => return non_eq,
+    };
+
     // Lexicographic ordering across path segments.
-    for (lhs, rhs) in lhs.segments.iter().zip(&rhs.segments) {
+    for (lhs, rhs) in lhs.1.segments.iter().zip(&rhs.1.segments) {
         match cmp_segment(&lhs.to_string(), &rhs.to_string(), mode) {
             Ordering::Equal => {}
             non_eq => return non_eq,
         }
     }
 
-    lhs.segments.len().cmp(&rhs.segments.len())
+    lhs.1.segments.len().cmp(&rhs.1.segments.len())
 }
 
 fn cmp_segment(lhs: &str, rhs: &str, mode: UnderscoreOrder) -> Ordering {

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -9,6 +9,7 @@ pub enum Kind {
     Match,
     Struct,
     Let,
+    Impl,
 }
 
 pub fn emit(err: Error, kind: Kind, output: TokenStream) -> TokenStream {
@@ -22,7 +23,7 @@ pub fn emit(err: Error, kind: Kind, output: TokenStream) -> TokenStream {
     let output = proc_macro2::TokenStream::from(output);
 
     let expanded = match kind {
-        Kind::Enum | Kind::Let | Kind::Struct => quote!(#err #output),
+        Kind::Enum | Kind::Let | Kind::Struct | Kind::Impl => quote!(#err #output),
         Kind::Match => quote!({ #err #output }),
     };
 
@@ -33,7 +34,7 @@ pub fn emit(err: Error, kind: Kind, output: TokenStream) -> TokenStream {
 // https://github.com/rust-lang/rust/issues/43081
 fn probably_has_spans(kind: Kind) -> bool {
     match kind {
-        Kind::Enum | Kind::Struct => true,
+        Kind::Enum | Kind::Struct | Kind::Impl => true,
         Kind::Match | Kind::Let => false,
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -10,6 +10,7 @@ pub enum Input {
     Match(syn::ExprMatch),
     Struct(syn::ItemStruct),
     Let(syn::ExprMatch),
+    Impl(syn::ItemImpl),
 }
 
 impl Input {
@@ -19,6 +20,7 @@ impl Input {
             Input::Match(_) => Kind::Match,
             Input::Struct(_) => Kind::Struct,
             Input::Let(_) => Kind::Let,
+            Input::Impl(_) => Kind::Impl,
         }
     }
 }
@@ -52,6 +54,10 @@ impl Parse for Input {
             return Ok(Input::Let(expr));
         }
 
+        if ahead.peek(Token![impl]) {
+            return input.parse().map(Input::Impl);
+        }
+
         let _: Visibility = ahead.parse()?;
         if ahead.peek(Token![enum]) {
             return input.parse().map(Input::Enum);
@@ -70,6 +76,7 @@ impl ToTokens for Input {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         match self {
             Input::Enum(item) => item.to_tokens(tokens),
+            Input::Impl(item) => item.to_tokens(tokens),
             Input::Struct(item) => item.to_tokens(tokens),
             Input::Match(expr) | Input::Let(expr) => expr.to_tokens(tokens),
         }
@@ -78,6 +85,6 @@ impl ToTokens for Input {
 
 fn unexpected() -> Error {
     let span = Span::call_site();
-    let msg = "expected enum, struct, or match expression";
+    let msg = "expected enum, impl, struct, or match expression";
     Error::new(span, msg)
 }


### PR DESCRIPTION
I have added support for the sorting of the `impl` section.

```rust
struct S;

#[remain::sorted]
impl S {
   fn a() {}
   fn b() {}
}
```

Category of items are sorted this way:

- consts
- type
- methods
- macros