### PR TITLE
Remove 'rustc is so bad at spans' workaround

### DIFF
--- a/src/emit.rs
+++ b/src/emit.rs
@@ -10,7 +10,7 @@ pub enum Kind {
     Let,
 }
 
-pub fn emit(err: Error, kind: Kind, output: TokenStream) -> TokenStream {
+pub fn emit(err: &Error, kind: Kind, output: TokenStream) -> TokenStream {
     let err = err.to_compile_error();
     let output = proc_macro2::TokenStream::from(output);
 

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -1,5 +1,4 @@
 use proc_macro::TokenStream;
-use proc_macro2::Span;
 use quote::quote;
 use syn::Error;
 
@@ -12,12 +11,6 @@ pub enum Kind {
 }
 
 pub fn emit(err: Error, kind: Kind, output: TokenStream) -> TokenStream {
-    let mut err = err;
-    if !probably_has_spans(kind) {
-        // Otherwise the error is printed without any line number.
-        err = Error::new(Span::call_site(), err);
-    }
-
     let err = err.to_compile_error();
     let output = proc_macro2::TokenStream::from(output);
 
@@ -27,13 +20,4 @@ pub fn emit(err: Error, kind: Kind, output: TokenStream) -> TokenStream {
     };
 
     TokenStream::from(expanded)
-}
-
-// Rustc is so bad at spans.
-// https://github.com/rust-lang/rust/issues/43081
-fn probably_has_spans(kind: Kind) -> bool {
-    match kind {
-        Kind::Enum | Kind::Struct => true,
-        Kind::Match | Kind::Let => false,
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,7 @@ pub fn sorted(args: TokenStream, input: TokenStream) -> TokenStream {
 
     match result {
         Ok(_) => output,
-        Err(err) => emit(err, kind, output),
+        Err(err) => emit(&err, kind, output),
     }
 }
 

--- a/tests/ui/let-unstable.stderr
+++ b/tests/ui/let-unstable.stderr
@@ -1,7 +1,5 @@
 error: E::Bbb should sort before E::Ccc
-  --> tests/ui/let-unstable.rs:15:5
+  --> tests/ui/let-unstable.rs:20:9
    |
-15 |     #[sorted]
-   |     ^^^^^^^^^
-   |
-   = note: this error originates in the attribute macro `sorted` (in Nightly builds, run with -Z macro-backtrace for more info)
+20 |         E::Bbb(_, _) => {}
+   |         ^^^^^^

--- a/tests/ui/match-unstable.stderr
+++ b/tests/ui/match-unstable.stderr
@@ -1,7 +1,5 @@
 error: E::Bbb should sort before E::Ccc
-  --> tests/ui/match-unstable.rs:15:5
+  --> tests/ui/match-unstable.rs:20:9
    |
-15 |     #[sorted]
-   |     ^^^^^^^^^
-   |
-   = note: this error originates in the attribute macro `sorted` (in Nightly builds, run with -Z macro-backtrace for more info)
+20 |         E::Bbb(_, _) => {}
+   |         ^^^^^^

--- a/tests/ui/unsorted-match-unstable.stderr
+++ b/tests/ui/unsorted-match-unstable.stderr
@@ -1,7 +1,5 @@
 error: E::Bbb should sort before E::Ddd
-  --> tests/ui/unsorted-match-unstable.rs:15:5
+  --> tests/ui/unsorted-match-unstable.rs:21:9
    |
-15 |     #[sorted]
-   |     ^^^^^^^^^
-   |
-   = note: this error originates in the attribute macro `sorted` (in Nightly builds, run with -Z macro-backtrace for more info)
+21 |         E::Bbb(_, _) => {}
+   |         ^^^^^^


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/43081 is (mostly?) no longer an issue since rust 1.53.